### PR TITLE
Add back u-root '-files' parameter for adding files

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -251,6 +251,7 @@ $(INITRAMFS_OUT): $(INITRAMFS_DEPS_FLAG) $(INITRAMFS_PATCH_FLAG)
 	GOPATH=$(INITRAMFS_BUILD_DIR)/gopath:$(UROOT_ADDITIONAL_GOPATH) \
 	  $(INITRAMFS_BUILD_DIR)/go/bin/go run github.com/u-root/u-root \
 	    -build=bb -o $@ -uinitcmd=$(UINIT_CMD) \
+	    $(addprefix -files=,$(BASE_FILES) $(UROOT_ADDITIONAL_FILES)) \
 	    $(UROOT_ADDITIONAL_CMDS) \
 	    $(UROOT_BASE_CMDS) \
 	  || { rm -f $@; exit 1; }


### PR DESCRIPTION
flashrom and vpd files were not added so vpdbootmanager doesn't
work.

Signed-off-by: Johnny Lin <johnny_lin@wiwynn.com>