### PR TITLE
Run a shell script 'vpd.sh' for VPD customization under your project

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -119,6 +119,7 @@ $(ROM_OUT): $(COREBOOT_OUT)
 	$(VPD_TOOL) -f "$<" -O -i RO_VPD -s internal_versions="`cat $(FINAL_CONFIG_OUT)`"
 	[ -z "$(VERSION)" ] || $(VPD_TOOL) -f "$<" -i RO_VPD -s firmware_version=$(VERSION)
 	$(VPD_TOOL) -f "$<" -O -i RW_VPD || true # Format RW_VPD region, if present.
+	[ -f "$(CURDIR)/vpd.sh" ] && bash "$(CURDIR)/vpd.sh" || echo "$(CURDIR)/vpd.sh doesn't exist"
 	cp "$<" "$@"
 	@echo '***' >&2
 	@echo '*** Build done, $@' >&2

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Entire build requires `PLATFORM` to be defined, this specifies the platform for 
  * `make wipe` will wipe everything, including downloaded deps.
    * `make wipe-coreboot` and `make wipe-kernel` will clean just the coreboot and kernel components.
    * Note that toolchain cache survives wipe and will be used in the next build.
+* You can place a shell script vpd.sh under your project folder which would be executed for your customized actions such as setting your VPD key-value pairs to your coreboot image.
 
 ## License
 

--- a/examples/qemu/vpd.sh
+++ b/examples/qemu/vpd.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+VPD="../../tools/vpd"
+ROM="build/qemu-x86_64/coreboot/build/coreboot.rom"
+
+#Or don't add '-O' that reformats the RO_VPD created by osf-builder/Makefile.inc
+$VPD -f $ROM -O -i RO_VPD -s fsp_log_enable=0
+$VPD -f $ROM -i RO_VPD -s test_key=123
+$VPD -f $ROM -O -i RW_VPD
+


### PR DESCRIPTION
The vpd.sh can do your own customization such as setting VPD variables during build. For example, project folder is osf-builder/projects/deltalake, you can place vpd.sh under deltalake with a vpd.sh script like: #!/bin/bash
VPD="../../tools/vpd"
ROM="build/deltalake/coreboot/build/coreboot.rom"

#Or don't add '-O' that reformats the RO_VPD created by osf-builder/Makefile.inc $VPD -f $ROM -O -i RO_VPD -s fsp_log_enable=0
$VPD -f $ROM -i RO_VPD -s test_key=123
$VPD -f $ROM -O -i RW_VPD

Signed-off-by: Johnny Lin <johnny_lin@wiwynn.com>