### PR TITLE
Makefile.inc: Add support for building AMD Onyx coreboot.

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -174,18 +174,20 @@ $(COREBOOT_TOOLCHAIN_OUT)/bin/iasl: $(COREBOOT_DEPS_FLAG) $(COREBOOT_PATCH_FLAG)
 # Creates coreboot config file using the user-provided one and feeding it to make olddefconfig.
 $(COREBOOT_CONFIG_OUT): $(COREBOOT_CONFIG) $(COREBOOT_DEPS_FLAG) $(COREBOOT_TOOLCHAIN_FLAG)
 	cp $(COREBOOT_CONFIG) $(COREBOOT_CONFIG_OUT)
-	if [ -d "$(COREBOOT_BLOBS_DIR)" ]; then \
-	  echo Using provided coreboot Intel blobs FSP, ME and microcode from $(COREBOOT_BLOBS_DIR) >&2; \
-	  sed -i "s|CONFIG_CPU_UCODE_BINARIES=.*|CONFIG_CPU_UCODE_BINARIES=\"$(COREBOOT_BLOBS_DIR)/microcode.mcb\"|" $@; \
-	  sed -i "s|CONFIG_FSP_T_FILE=.*|CONFIG_FSP_T_FILE=\"$(COREBOOT_BLOBS_DIR)/Server_T.fd\"|" $@; \
-	  sed -i "s|CONFIG_FSP_M_FILE=.*|CONFIG_FSP_M_FILE=\"$(COREBOOT_BLOBS_DIR)/Server_M.fd\"|" $@; \
-	  sed -i "s|CONFIG_FSP_S_FILE=.*|CONFIG_FSP_S_FILE=\"$(COREBOOT_BLOBS_DIR)/Server_S.fd\"|" $@; \
-	  sed -i "s|CONFIG_IFD_BIN_PATH=.*|CONFIG_IFD_BIN_PATH=\"$(COREBOOT_BLOBS_DIR)/flashregion_0_flashdescriptor.bin\"|" $@; \
-	  sed -i "s|CONFIG_ME_BIN_PATH=.*|CONFIG_ME_BIN_PATH=\"$(COREBOOT_BLOBS_DIR)/flashregion_2_intel_me.bin\"|" $@; \
-	fi
+	ifndef NO_INTEL_BLOBS
+		if [ -d "$(COREBOOT_BLOBS_DIR)" ]; then \
+		  echo Using provided coreboot Intel blobs FSP, ME and microcode from $(COREBOOT_BLOBS_DIR) >&2; \
+		  sed -i "s|CONFIG_CPU_UCODE_BINARIES=.*|CONFIG_CPU_UCODE_BINARIES=\"$(COREBOOT_BLOBS_DIR)/microcode.mcb\"|" $@; \
+		  sed -i "s|CONFIG_FSP_T_FILE=.*|CONFIG_FSP_T_FILE=\"$(COREBOOT_BLOBS_DIR)/Server_T.fd\"|" $@; \
+		  sed -i "s|CONFIG_FSP_M_FILE=.*|CONFIG_FSP_M_FILE=\"$(COREBOOT_BLOBS_DIR)/Server_M.fd\"|" $@; \
+		  sed -i "s|CONFIG_FSP_S_FILE=.*|CONFIG_FSP_S_FILE=\"$(COREBOOT_BLOBS_DIR)/Server_S.fd\"|" $@; \
+		  sed -i "s|CONFIG_IFD_BIN_PATH=.*|CONFIG_IFD_BIN_PATH=\"$(COREBOOT_BLOBS_DIR)/flashregion_0_flashdescriptor.bin\"|" $@; \
+		  sed -i "s|CONFIG_ME_BIN_PATH=.*|CONFIG_ME_BIN_PATH=\"$(COREBOOT_BLOBS_DIR)/flashregion_2_intel_me.bin\"|" $@; \
+		fi
+		! grep -q CONFIG_INTEL_CBNT_PROV_EXTERNAL_BIN=y $@ || \
+		  sed -i "s|CONFIG_INTEL_CBNT_PROV_EXTERNAL_BIN_PATH=.*|CONFIG_INTEL_CBNT_PROV_EXTERNAL_BIN_PATH=\"$(CBNT_PROV_TOOL)\"|" $@
+	endif
 	sed -i "s|CONFIG_PAYLOAD_FILE=.*|CONFIG_PAYLOAD_FILE=\"$(KERNEL_IN)\"|" $@
-	! grep -q CONFIG_INTEL_CBNT_PROV_EXTERNAL_BIN=y $@ || \
-	  sed -i "s|CONFIG_INTEL_CBNT_PROV_EXTERNAL_BIN_PATH=.*|CONFIG_INTEL_CBNT_PROV_EXTERNAL_BIN_PATH=\"$(CBNT_PROV_TOOL)\"|" $@
 	MAKEFLAGS= $(MAKE) -C $(COREBOOT_BUILD_DIR) olddefconfig
 
 clean-coreboot:


### PR DESCRIPTION
This change uses an AMD coreboot defined variable from their projects Makefile, to avoid using the Intel specific coreboot config changes implemented in the osf-builder Makefile.inc

Signed-off-by: Eddie Vas <aeddiesharma@meta.com>