### PR TITLE
examples/qemu: Add u-root boot command

### DIFF
--- a/examples/qemu/Makefile
+++ b/examples/qemu/Makefile
@@ -11,6 +11,8 @@ OSF_BUILDER_DIR := ../..
 # CONFIG, KERNEL_CONFIG and COREBOOT_CONFIG are derived from CONFIGS_DIR and PLATFORM.
 CONFIGS_DIR := ./configs
 PATCHES_DIR := ./patches
+UROOT_ADDITIONAL_CMDS := \
+	github.com/u-root/u-root/cmds/boot/boot
 
 include $(OSF_BUILDER_DIR)/Makefile.inc
 


### PR DESCRIPTION
So people can use boot as their u-root initcmd.
To only build LinuxBoot payload with boot as initcmd: make UINIT_CMD=boot kernel

u-root initcmd please reference:
https://github.com/u-root/u-root#init-and-uinit